### PR TITLE
Kafka flow scheduling 

### DIFF
--- a/saxswaxs_workflows/flows/kafka_flow_scheduler.py
+++ b/saxswaxs_workflows/flows/kafka_flow_scheduler.py
@@ -19,7 +19,10 @@ logger.addHandler(logging.StreamHandler())
 
 
 parameters = JSON.load("2017-10-31-gisaxs-horizontal-cut").value
-KAFKA_TOPIC = os.getenv("KAFKA_TOPIC")
+KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "new_scan_entry")
+KAFKA_BOOTSTRAP_SERVER = os.getenv(
+    "KAFKA_BOOTSTRAP_SERVER", "localhost:9092"
+)  # kafka port
 
 
 consumer = KafkaConsumer(

--- a/saxswaxs_workflows/flows/kafka_flow_scheduler.py
+++ b/saxswaxs_workflows/flows/kafka_flow_scheduler.py
@@ -1,0 +1,71 @@
+import json
+import asyncio
+import logging
+import os
+
+from kafka import KafkaConsumer
+
+from prefect.blocks.system import JSON
+from utils_prefect import _schedule
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+logger = logging.getLogger("data_watcher")
+logger.setLevel("INFO")
+logname = "data_watcher_p03"
+logger.addHandler(logging.StreamHandler())
+
+
+parameters = JSON.load("2017-10-31-gisaxs-horizontal-cut").value
+KAFKA_TOPIC = os.getenv("KAFKA_TOPIC")
+
+
+consumer = KafkaConsumer(
+    KAFKA_TOPIC,
+    bootstrap_servers="localhost:9092",
+    value_deserializer=lambda m: json.loads(m.decode("utf-8"))
+    # Convert JSON bytes back to dict
+)
+
+async def schedule_flow(input_file_uri):
+    # schedule the flow
+    parameters["input_uri_data"] = input_file_uri
+
+    await _schedule(
+        deployment_name="pixel-roi-horizontal-cut-tiled/horizontal-cut",
+        # deployment_name="saxs-waxs-azimuthal-integration-tiled/integration-azimuthal",
+        flow_run_name=input_file_uri,
+        parameters=parameters,
+    )
+
+async def kafka_consumer_scheduler():
+
+    # Read and print messages
+    for message in consumer:
+        print(f"Received message: {message.value}")
+
+        #split the message to get the uri
+        input_file_uri = message.value["scan_uri"]
+
+        parameters["input_uri_data"] = input_file_uri
+        logger.info(f"Scheduling flows with {input_file_uri}")
+
+        await schedule_flow(input_file_uri)
+
+
+if __name__ == "__main__":
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError as e:
+        if str(e).startswith("There is no current event loop in thread"):
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        else:
+            raise
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(kafka_consumer_scheduler())
+
+    # asyncio.run(schedule_flow("raw/2024_10_31 GISAXS/1_8_A0p120_A0p121_sfloat_2m"))


### PR DESCRIPTION
We are now able to receive messages from a kafka stream, and schedule a flow that starts off the reduction process. This serves as an alternative to the file watcher, and would require the data to have been ingested in Tiled before this process is lauched.